### PR TITLE
getDriverConfig(), getConfigFile() in BaseTestCase made abstract.

### DIFF
--- a/webdriver-core-test/src/main/java/se/soprasteria/automatedtesting/webdriver/android/AndroidBaseTestCase.java
+++ b/webdriver-core-test/src/main/java/se/soprasteria/automatedtesting/webdriver/android/AndroidBaseTestCase.java
@@ -12,12 +12,12 @@ public class AndroidBaseTestCase extends BaseTestCase {
     protected SwipePageObject swipePage;
 
     @Override
-    protected String getDefaultDriverConfig() {
+    protected String getDriverConfig() {
         return "android";
     }
 
     @Override
-    protected String getDefaultPropertyFile() {
+    protected String getConfigFile() {
         return "config.xml";
     }
 

--- a/webdriver-core-test/src/main/java/se/soprasteria/automatedtesting/webdriver/web/WebBaseTestCase.java
+++ b/webdriver-core-test/src/main/java/se/soprasteria/automatedtesting/webdriver/web/WebBaseTestCase.java
@@ -12,7 +12,7 @@ import se.soprasteria.automatedtesting.webdriver.web.model.pages.ScrollPage;
 
 import java.awt.*;
 
-public abstract class WebBaseTestCase extends BaseTestCase {
+public class WebBaseTestCase extends BaseTestCase {
 
     protected DriverMethods driverMethods;
     protected WaitForElementMethods waitForElementMethods;
@@ -27,23 +27,23 @@ public abstract class WebBaseTestCase extends BaseTestCase {
 
 
     @Override
-    protected String getDefaultDriverConfig() {
-        return "chromedriver";
-    }
-
-    @Override
-    protected String getDefaultPropertyFile() {
-        return "config.xml";
-    }
-
-    @Override
-    protected String getDefaultDebugLevel() {
+    protected String getDebugLevel() {
         return "IMAGES_FAIL";
     }
 
     @Override
     protected void initializeDriver(AutomationDriver driver) {
         initPages(driver);
+    }
+
+    @Override
+    protected String getDriverConfig() {
+        return "chromedriver";
+    }
+
+    @Override
+    protected String getConfigFile() {
+        return "config.xml";
     }
 
     private void initPages(AutomationDriver driver){

--- a/webdriver-core/src/main/java/se/soprasteria/automatedtesting/webdriver/api/base/BDDFactory.java
+++ b/webdriver-core/src/main/java/se/soprasteria/automatedtesting/webdriver/api/base/BDDFactory.java
@@ -113,8 +113,8 @@ public class BDDFactory extends BaseTestCase {
                                   @Optional("") String baseTestCase,
                                   @Optional("unspecified") String bddResultPackageName) {
 
-        this.configurationId = Data.ifEmptyOverride(logger, configurationId, getDefaultDriverConfig());
-        this.propertiesFile = Data.ifEmptyOverride(logger, propertiesFile, getDefaultPropertyFile());
+        this.configurationId = Data.ifEmptyOverride(logger, configurationId, getDriverConfig());
+        this.propertiesFile = Data.ifEmptyOverride(logger, propertiesFile, getConfigFile());
         this.config = BaseTestConfig.getInstance(this.propertiesFile);
 
         featureFolder = Data.ifEmptyOverride(logger, featureFolder, getDefaultFolderContainingFeatureFiles());
@@ -239,4 +239,13 @@ public class BDDFactory extends BaseTestCase {
         return generatedScenarios;
     }
 
+    @Override
+    protected String getDriverConfig() {
+        return "chromedriver";
+    }
+
+    @Override
+    protected String getConfigFile() {
+        return "resources/config.xml";
+    }
 }

--- a/webdriver-core/src/main/java/se/soprasteria/automatedtesting/webdriver/api/base/BaseTestCase.java
+++ b/webdriver-core/src/main/java/se/soprasteria/automatedtesting/webdriver/api/base/BaseTestCase.java
@@ -151,10 +151,10 @@ public abstract class BaseTestCase extends BaseClass {
     protected void initSuite(final ITestContext testContext,
                              @Optional("") String propertiesFile,
                              @Optional("") String configurationId) {
-        config = BaseTestConfig.getInstance(Data.ifEmptyOverride(logger, propertiesFile, getDefaultPropertyFile()), testContext);
+        config = BaseTestConfig.getInstance(Data.ifEmptyOverride(logger, propertiesFile, getConfigFile()), testContext);
         BaseTestSuite.initializeRuntimeEnvironment(
                 BTCHelper.getDriverConfigurations(
-                        logger,Data.ifEmptyOverride(logger, configurationId, getDefaultDriverConfig())));
+                        logger,Data.ifEmptyOverride(logger, configurationId, getDriverConfig())));
         setConfigurationOptions();
         MockedData.initServerPorts(logger);
     }
@@ -182,11 +182,11 @@ public abstract class BaseTestCase extends BaseClass {
                                  @Optional("") String configurationId,
                                  @Optional("") String debugLevel) {
         logger.info("INIT CLASS: " + this.getClass().getSimpleName());
-        config = BaseTestConfig.getInstance(Data.ifEmptyOverride(logger, propertiesFile, getDefaultPropertyFile()));
-        this.configurationId = Data.ifEmptyOverride(logger, configurationId, getDefaultDriverConfig());
+        config = BaseTestConfig.getInstance(Data.ifEmptyOverride(logger, propertiesFile, getConfigFile()));
+        this.configurationId = Data.ifEmptyOverride(logger, configurationId, getDriverConfig());
         this.testSuiteName = testContext.getName();
         if (BaseTestConfig.getInstance().getConfig().users != null) this.credentials = new Credentials();
-        DebugLevel.set(Data.ifEmptyOverride(logger, debugLevel, getDefaultDebugLevel()));
+        DebugLevel.set(Data.ifEmptyOverride(logger, debugLevel, getDebugLevel()));
         Session.setCurrentConfigurationId(this.configurationId);
         startAppium();
     }
@@ -256,25 +256,16 @@ public abstract class BaseTestCase extends BaseClass {
     }
 
     /**
-     * Get the default configuration ID for which webdriver to use. This is only used if no valid parameter was found
-     * in the TestNG XML file. Override this in the testcase in the project specific basetestcase if you prefer a
-     * different webdriver to be used by default.
-     *
-     * @return configuration id.
+     * Abstract method that must always be implemented to specify what webdriver that should be used.
+     * @return driver config id.
      */
-    protected String getDefaultDriverConfig() {
-        return "chromedriver";
-    }
+    protected abstract String getDriverConfig();
 
     /**
-     * Get the default path to the properties file. This is only used if no valid parameter was found in the TestNG XML
-     * file. Override this method in the project specific basetestcase if you prefer another default path.
-     *
+     * Abstract method that must be implemented to specify the path to the config xml file.
      * @return path to property file.
      */
-    protected String getDefaultPropertyFile() {
-        return "reference/config.xml";
-    }
+    protected abstract String getConfigFile();
 
     /**
      * Override this function to specify if a generated appium log should be printed. If not overridden
@@ -346,7 +337,7 @@ public abstract class BaseTestCase extends BaseClass {
      *
      * @return - Default debugtype
      */
-    protected String getDefaultDebugLevel() {
+    protected String getDebugLevel() {
         return DebugLevel.DEFAULT_LEVEL.name();
     }
 


### PR DESCRIPTION
User must implement these methods in the app specific basetestcase class